### PR TITLE
Add .NET 4.5 as an additional target framework.

### DIFF
--- a/src/NExifTool/NExifTool.csproj
+++ b/src/NExifTool/NExifTool.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>NExifTool</AssemblyTitle>
     <VersionPrefix>0.8.2</VersionPrefix>
     <Authors>Mike Morano &lt;mmorano@mikeandwan.us&gt;</Authors>
-    <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net461;net45</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>NExifTool</AssemblyName>
@@ -25,5 +25,13 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.6.1" Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.5\1.0.1\lib\net45\</FrameworkPathOverride>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45' ">
+    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.5" Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I'm looking to use NExifTool in a large project that is stuck targeting .NET 4.5 for some time and thought I would see if there was any issue if current version of NExiftool added 4.5 as an additional target. 

I've run the unit tests and tried in two different .NET 4.5 solutions and had no issue using the library as expected. 